### PR TITLE
Changes to schema post-PRA comments and feedback

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,44 +35,58 @@ Health Plans - plans.json
 
 ### Schema
 
-| Field                          | Label                    | Definition                                                                                                 | Required |
-| -----                          | -----                    | ----------                                                                                                 | -------- |
-| **plan_id_type**               | ID Type                  | Type of Plan ID. The preferred is the HIOS Plan ID - `HIOS-PLAN-ID`  | Always   |
-| **plan_id**                         | Unique Identifier        | The 14-character, HIOS-generated Plan ID number. (Plan IDs must be unique, even across different markets.) | Always   |
-| **marketing_name**             | Marketing Name           | The name of the plan as it is displayed on HealthCare.gov                                                  | Always   |
-| **summary_url**              | URL for Plan Information | The URL that goes directly to the summary of benefits and coverage for the specific standard plan or plan variation.          | Yes       |
-| **marketing_url**              | URL for Plan Information | The URL that goes directly to the plan brochure for the specific standard plan or plan variation.          | No       |
-| **plan_contact**              | Contact Email Address for Plan | An email address for developers/public to report mistakes in the network and formulary data.          | Always       |
-| **network**                | Network                 | Array of networks                                                                                          | Always   |
-| **formulary**              | Formularies              | Array of drug lists                                                                                       | Always   |
-| **last_updated_on**          | Last Updated On          | ISO 8601 format (e.g. YYYY-MM-DD)   
+| Field               | Label                          | Definition                                                                                                           | Required |
+| -----               | -----                          | ----------                                                                                                           | -------- |
+| **plan_id_type**    | ID Type                        | Type of Plan ID. The preferred is the HIOS Plan ID - `HIOS-PLAN-ID`                                                  | Always   |
+| **plan_id**         | Unique Identifier              | The 14-character, HIOS-generated Plan ID number. (Plan IDs must be unique, even across different markets.)           | Always   |
+| **marketing_name**  | Marketing Name                 | The name of the plan as it is displayed on HealthCare.gov                                                            | Always   |
+| **summary_url**     | URL for Plan Information       | The URL that goes directly to the summary of benefits and coverage for the specific standard plan or plan variation. | Always   |
+| **marketing_url**   | URL for Plan Information       | The URL that goes directly to the plan brochure for the specific standard plan or plan variation.                    | No       |
+| **formulary_url**  | URL for Formulary              | The URL that goes directly to the formulary brochure for the specific standard plan or plan variation.                    | No       |
+| **plan_contact**    | Contact Email Address for Plan | An email address for developers/public to report mistakes in the network and formulary data.                         | Always   |
+| **network**         | Network                        | Array of networks                                                                                                    | Always   |
+| **formulary**       | Formularies                    | Array of drug lists                                                                                                  | Always   |
+| **benefits**       | Benefits                    | Array of benefits                                                                                                  | No   |
+| **last_updated_on** | Last Updated On                | ISO 8601 format (e.g. YYYY-MM-DD) | Always   |
 
 
 #### Network sub-type
 
-| Field         | Label      | Definition                                    | Required |
-| -----                          | -----                    | ----------                                                                                                 | -------- |
-| ***network_tier***             | Network Tier             | Tier for network (Example Values: `PREFERRED`, `NON-PREFERRED`, etc. Values should be all uppercase. )                                                          | Always   |
+| Field              | Label        | Definition                                                                                             | Required |
+| -----              | -----        | ----------                                                                                             | -------- |
+| ***network_tier*** | Network Tier | Tier for network (Example Values: `PREFERRED`, `NON-PREFERRED`, etc. Values should be all uppercase. ) | Always   |
 
 
 #### Formulary sub-type
 
-| Field                          | Label                    | Definition                                                                                                 | Required |
-| -----                          | -----                    | ----------                                                                                                 | -------- |
-| ***drug_tier***           | Drug Tier           | Tier for formulary - (Example Values: `GENERIC`, `PREFERRED-GENERIC`, `NON-PREFERRED-GENERIC`, `SPECIALTY`, `BRAND`, `PREFERRED-BRAND`, `NON-PREFERRED-BRAND`, `ZERO-COST-SHARE-PREVENTIVE`, `MEDICAL-SERVICE`, etc. Values should be all uppercase.  )                        | Always   |
-| ***mail_order***               | Mail Order               | Does the formulary cover mail order? - (Values: `true` or `false`)                                                 | Always   |
-| ***cost_sharing***             | Cost Sharing             | Array of cost sharing values (see "Cost sharing sub-type" below)                                                                              | Always   |                                                                       | Always   |
+| Field              | Label        | Definition                                                                                                                                                                                                                                            | Required |
+| -----              | -----        | ----------                                                                                                                                                                                                                                            | -------- |
+| ***drug_tier***    | Drug Tier    | Tier for formulary - (Example Values: `GENERIC`, `PREFERRED-GENERIC`, `NON-PREFERRED-GENERIC`, `SPECIALTY`, `BRAND`, `PREFERRED-BRAND`, `NON-PREFERRED-BRAND`, `ZERO-COST-SHARE-PREVENTIVE`, `MEDICAL-SERVICE`, etc. Values should be all uppercase.) | Always   |
+| ***mail_order***   | Mail Order   | Does the formulary cover mail order? - (Values: `true` or `false`)                                                                                                                                                                                    | Always   |
+| ***cost_sharing*** | Cost Sharing | Array of cost sharing values (see "Cost sharing sub-type" below)                                                                                                                                                                                      | Always   |
 
 
 #### Cost sharing sub-type
 
-| Field            | Label              | Definition                                                                                                            | Required |
-| -----            | -----              | ----------                                                                                                            | -------- |
-| **pharmacy_type**    | Pharmacy Type      | Pharmacy type (Example Values: `1-MONTH-IN-RETAIL`, `1-MONTH-OUT-RETAIL`, `1-MONTH-IN-MAIL`, `1-MONTH-OUT-MAIL`, `3-MONTH-IN-RETAIL`, `3-MONTH-OUT-RETAIL`, `3-MONTH-IN-MAIL`, `3-MONTH-OUT-MAIL`)                                              | Always   |
-| **copay_amount**     | Copay amount       | Amount of copay, in $ (number)                                                                                        | Always   |
-| **copay_opt**        | Copay option       | Qualifier of copay amount (Values: `AFTER-DEDUCTIBLE`, `BEFORE-DEDUCTIBLE`, `NO-CHARGE`, `NO-CHARGE-AFTER-DEDUCTIBLE` | No       |
-| **coinsurance_rate** | Coinsurance rate   | Rate of coinsurance (float, 0.0 to 1.0)                                                                    | Always   |
-| **coinsurance_opt** | Coinsurance option | Qualifier for coinsurance rate (Values: `AFTER-DEDUCTIBLE`, `NO-CHARGE`, `NO-CHARGE-AFTER-DEDUCTIBLE`)                | No       |
+| Field                | Label              | Definition                                                                                                                                                                                         | Required |
+| -----                | -----              | ----------                                                                                                                                                                                         | -------- |
+| **pharmacy_type**    | Pharmacy Type      | Pharmacy type (Example Values: `1-MONTH-IN-RETAIL`, `1-MONTH-OUT-RETAIL`, `1-MONTH-IN-MAIL`, `1-MONTH-OUT-MAIL`, `3-MONTH-IN-RETAIL`, `3-MONTH-OUT-RETAIL`, `3-MONTH-IN-MAIL`, `3-MONTH-OUT-MAIL`) | Always   |
+| **copay_amount**     | Copay amount       | Amount of copay, in $ (number)                                                                                                                                                                     | Always   |
+| **copay_opt**        | Copay option       | Qualifier of copay amount (Values: `AFTER-DEDUCTIBLE`, `BEFORE-DEDUCTIBLE`, `NO-CHARGE`, `NO-CHARGE-AFTER-DEDUCTIBLE`                                                                              | Always   |
+| **coinsurance_rate** | Coinsurance rate   | Rate of coinsurance (float, 0.0 to 1.0)                                                                                                                                                            | Always   |
+| **coinsurance_opt**  | Coinsurance option | Qualifier for coinsurance rate (Values: `AFTER-DEDUCTIBLE`, `NO-CHARGE`, `NO-CHARGE-AFTER-DEDUCTIBLE`)                                                                                             | Always   |
+
+
+#### Benefits sub-type
+
+The **Benefits** sub-type is an optional section and will be shaped depending on what industry and consumers find valuable. 
+
+For example, many health plans are offering telemedicine as an additional health benefit and that can be highlighted by adding a `telemedicine` entry.
+
+| Field                | Label              | Definition                                                                                                                                                                                         | Required |
+| -----                | -----              | ----------                                                                                                                                                                                         | -------- |
+| **telemedicine**    | Offers Telemedicine     | Does the plan cover telemedicine? - (Values: `true` or `false`)    | No   |
+
 
 ### Example 
 
@@ -84,6 +98,7 @@ Health Plans - plans.json
         "marketing_name": "Sample Gold Health Plan",
         "summary_url": "http://url/to/summary/benefits/coverage",
         "marketing_url": "http://url/to/health/plan/information",
+        "formulary_url": "http://url/to/formulary/information",
         "plan_contact": "email@address.com",
         "network": [
             {
@@ -149,54 +164,57 @@ Providers - providers.json
 
 ### Schema
 
-| Field      | Label                | Definition                                                                                                 | Required |
-| -----      | -----                | ----------                                                                                                 | -------- |
-| **npi**        | National Provider ID | The National Provider Identifier (NPI) is a unique identification number for covered health care providers | Always   |
-| **type**       | Type                 | Specify if `INDIVIDUAL` or `FACILITY`                                                                      | Always   |
-| **plans**      | Plans    | Array of plans that cover this provider (see "Plans sub-type" below) | Always |
+| Field     | Label                | Definition                                                                                                 | Required |
+| -----     | -----                | ----------                                                                                                 | -------- |
+| **npi**   | National Provider ID | The National Provider Identifier (NPI) is a unique identification number for covered health care providers | Always   |
+| **type**  | Type                 | Specify if `INDIVIDUAL` or `FACILITY`                                                                      | Always   |
+| **plans** | Plans                | Array of plans that cover this provider (see "Plans sub-type" below)                                       | Always   |
+| **last_updated_on** | Last Updated On                | Date of when the record for this provider has been last updated or refreshed - ISO 8601 format (e.g. YYYY-MM-DD)                | Always   |
 
 If the entry is for an `INDIVIDUAL` then the following fields should be present:
 
-| Field     | Label              | Definition                                                 | Required |
-| -----     | -----              | ----------                                                 | -------- |
-| **name**      | Name               | -                                                           | Always   |
-| ***prefix***    | Prefix             | -                                                           | No       |
-| ***first***   | First Name         | -                                                           | Always   |
-| ***middle***  | Middle Name        | -                                                           | Always   |
-| ***last***    | Last Name          | -                                                           | Always   |
-| ***suffix***    | Suffix             | -                                                           | No       |
-| **address**   | Address            | -                                                           | Always   |
-| ***address*** | Street Address   | -                                                           | Always       |
-| ***address_2*** | Street Address 2   | -                                                           | No       |
-| ***city***    | City               | -                                                           | Always   |
-| ***state***   | State Abbreviation | -                                                           | Always   |
-| ***zip***     | Zip Code           | -                                                           | Always   |
-| **phone**   | Phone Number            | -                                                           | Always   |
-| **specialty** | Specialty Type     | -                                                           | Always   |
-| **accepting** | Accepting Patients | Is the provider accepting patients? - (Values: `true` or `false`)    | Always   |
+| Field           | Label              | Definition                                                        | Required |
+| -----           | -----              | ----------                                                        | -------- |
+| **name**        | Name               | -                                                                 | Always   |
+| ***prefix***    | Prefix             | -                                                                 | No       |
+| ***first***     | First Name         | -                                                                 | Always   |
+| ***middle***    | Middle Name        | -                                                                 | No       |
+| ***last***      | Last Name          | -                                                                 | Always   |
+| ***suffix***    | Suffix             | -                                                                 | No       |
+| **address**     | Address            | -                                                                 | Always   |
+| ***address***   | Street Address     | -                                                                 | Always   |
+| ***address_2*** | Street Address 2   | -                                                                 | No       |
+| ***city***      | City               | -                                                                 | Always   |
+| ***state***     | State Abbreviation | -                                                                 | Always   |
+| ***zip***       | Zip Code           | -                                                                 | Always   |
+| **phone**       | Phone Number       | -                                                                 | Always   |
+| **specialty**   | Specialty Type     | An array of speciality types.                                     | Always   |
+| **accepting**   | Accepting Patients | Is the provider accepting patients? - (Values: `true` or `false`) | Always   |
+| **gender**      | Gender             | Values: `Male`, `Female`, `Other`                                 | Optional   |
+| **languages**   | Languages Spoken   | An array of the languages spoken                                  | Optional   |
 
 If the entry is for a `FACILITY` then the following fields should be present:
 
-| Field         | Label              | Definition | Required |
-| -----         | -----              | ---------- | -------- |
-| **facility_name** | Facility Name      | -           | Always   |
-| **facility_type** | Facility Type      | -           | Always   |
-| **address**       | Address            | -           | Always   |
-| ***address***     | Street Address   | -           | Always       |
-| ***address_2***     | Street Address 2   | -           | No       |
-| ***city***        | City               | -           | Always   |
-| ***state***       | State Abbreviation | -           | Always   |
-| ***zip***         | Zip Code           | -           | Always   |
-| **phone**   | Phone Number            | -                                                           | Always   |
+| Field             | Label              | Definition | Required |
+| -----             | -----              | ---------- | -------- |
+| **facility_name** | Facility Name      | -          | Always   |
+| **facility_type** | Facility Type      | An array of facility types. | Always   |
+| **address**       | Address            | -          | Always   |
+| ***address***     | Street Address     | -          | Always   |
+| ***address_2***   | Street Address 2   | -          | No       |
+| ***city***        | City               | -          | Always   |
+| ***state***       | State Abbreviation | -          | Always   |
+| ***zip***         | Zip Code           | -          | Always   |
+| **phone**         | Phone Number       | -          | Always   |
 
 
 #### Plans sub-type
 
-| Field            | Label              | Definition                                                                                                            | Required |
-| -----            | -----              | ----------                                                                                                            | -------- |
-| ***plan_id_type***                    | ID Type                  | Type of Plan ID. The preferred is the HIOS Plan ID - `HIOS-PLAN-ID`  | Always   |
-| ***plan_id***                         | Unique Identifier        | The 14-character, HIOS-generated Plan ID number. (Plan IDs must be unique, even across different markets.) | Always   |
-| ***network_tier***             | Network Tier             | Tier for network (Example Values: `PREFERRED`, `NON-PREFERRED`, etc. Values should be all uppercase. )                                                          | Always   |
+| Field              | Label             | Definition                                                                                                 | Required |
+| -----              | -----             | ----------                                                                                                 | -------- |
+| ***plan_id_type*** | ID Type           | Type of Plan ID. The preferred is the HIOS Plan ID - `HIOS-PLAN-ID`                                        | Always   |
+| ***plan_id***      | Unique Identifier | The 14-character, HIOS-generated Plan ID number. (Plan IDs must be unique, even across different markets.) | Always   |
+| ***network_tier*** | Network Tier      | Tier for network (Example Values: `PREFERRED`, `NON-PREFERRED`, etc. Values should be all uppercase. )     | Always   |
 
 
 ### Example
@@ -220,7 +238,7 @@ If the entry is for a `FACILITY` then the following fields should be present:
             "zip": "72201"
         },
         "phone": "2025551212",
-        "specialty": "Ophthalmology",
+        "specialty": ["Ophthalmology"],
         "accepting": true,
         "plans": [
             {
@@ -233,13 +251,15 @@ If the entry is for a `FACILITY` then the following fields should be present:
                 "plan_id": "12345XX9876543",
                 "network_tier": "NON-PREFERRED"
             }
-        ]
+        ],
+        "languages": ["English", "Spanish", "Mandarin"],
+        "last_updated_on": "2015-03-17"
     },
     {
         "npi": "1234567890123949",
         "type": "FACILITY",
         "facility_name": "Main Street Hospital",
-        "facility_type": "Hospital",
+        "facility_type": ["Hospital"],
         "address": {
             "address": "123 Main Street",
             "address_2": "Suite 120",
@@ -259,7 +279,8 @@ If the entry is for a `FACILITY` then the following fields should be present:
                 "plan_id": "12345XX9876543",
                 "network_tier": "NON-PREFERRED"
             }
-        ]
+        ],
+        "last_updated_on": "2015-03-17"
     }
 ]
 ```
@@ -273,23 +294,23 @@ Drugs - drugs.json
 
 ### Schema
 
-| Field               | Label                        | Definition                                                                 | Required |
-| -----               | -----                        | ----------                                                                 | -------- |
-| **rxnorm_id**     | Drug Identifier              | RxCUI (Specific drug identifier from RXNORM)                                       | Always   |
-| **drug_name**           | Drug Name                    | Name of Drug                                                               | Always   |
-| **plans**           | Plans                   | Array of plans that cover this drug (see "Plans sub-type" below)                                                        | Always   |
+| Field         | Label           | Definition                                                       | Required |
+| -----         | -----           | ----------                                                       | -------- |
+| **rxnorm_id** | Drug Identifier | RxCUI (Specific drug identifier from RXNORM)                     | Always   |
+| **drug_name** | Drug Name       | Name of Drug                                                     | Always   |
+| **plans**     | Plans           | Array of plans that cover this drug (see "Plans sub-type" below) | Always   |
 
 
 #### Plans sub-type
 
-| Field            | Label              | Definition                                                                                                            | Required |
-| -----            | -----              | ----------                                                                                                            | -------- |
-| ***plan_id_type***                    | ID Type                  | Type of Plan ID. The preferred is the HIOS Plan ID - `HIOS-PLAN-ID`  | Always   |
-| ***plan_id***                         | Unique Identifier        | The 14-character, HIOS-generated Plan ID number. (Plan IDs must be unique, even across different markets.) | Always   |
-| ***drug_tier***             | Drug Tier             | Tier for formulary (Example Values: `GENERIC`, `PREFERRED-GENERIC`, `NON-PREFERRED-GENERIC`, `SPECIALTY`, `BRAND`, `PREFERRED-BRAND`, `NON-PREFERRED-BRAND`, `ZERO-COST-SHARE-PREVENTIVE`, `MEDICAL-SERVICE`, etc. Values should be all uppercase. )                                                          | Always   |
-| ***prior_authorization*** | Prior Authorization Required | Is prior authorization required? - (Values: `true` or `false`)                    | Always   |
-| ***step_therapy***        | Step Therapy Required        | Is step therapy required? - (Values: `true` or `false`)                           | Always   |
-| ***quantity_limit***        | Quantity Limit        | Is there a quantity limit for this drug? - (Values: `true` or `false`)                           | Always   |
+| Field                     | Label                        | Definition                                                                                                                                                                                                                                           | Required |
+| -----                     | -----                        | ----------                                                                                                                                                                                                                                           | -------- |
+| ***plan_id_type***        | ID Type                      | Type of Plan ID. The preferred is the HIOS Plan ID - `HIOS-PLAN-ID`                                                                                                                                                                                  | Always   |
+| ***plan_id***             | Unique Identifier            | The 14-character, HIOS-generated Plan ID number. (Plan IDs must be unique, even across different markets.)                                                                                                                                           | Always   |
+| ***drug_tier***           | Drug Tier                    | Tier for formulary (Example Values: `GENERIC`, `PREFERRED-GENERIC`, `NON-PREFERRED-GENERIC`, `SPECIALTY`, `BRAND`, `PREFERRED-BRAND`, `NON-PREFERRED-BRAND`, `ZERO-COST-SHARE-PREVENTIVE`, `MEDICAL-SERVICE`, etc. Values should be all uppercase. ) | Always   |
+| ***prior_authorization*** | Prior Authorization Required | Is prior authorization required? - (Values: `true` or `false`)                                                                                                                                                                                       | Always   |
+| ***step_therapy***        | Step Therapy Required        | Is step therapy required? - (Values: `true` or `false`)                                                                                                                                                                                              | Always   |
+| ***quantity_limit***      | Quantity Limit               | Is there a quantity limit for this drug? - (Values: `true` or `false`)                                                                                                                                                                               | Always   |
 
 
 
@@ -311,7 +332,7 @@ Drugs - drugs.json
             },
             {
                 "plan_id_type": "HIOS-PLAN-ID",
-                "plan_id": "56748XX1239330",
+                "plan_id": "56748XXX123933",
                 "drug_tier": "GENERIC",
                 "prior_authorization": false,
                 "step_therapy": false,
@@ -333,7 +354,7 @@ Drugs - drugs.json
             },
             {
                 "plan_id_type": "HIOS-PLAN-ID",
-                "plan_id": "56748XX1239330",
+                "plan_id": "56748XXX123933",
                 "drug_tier": "GENERIC",
                 "prior_authorization": false,
                 "step_therapy": false,


### PR DESCRIPTION
Makes schema consistent with validator tool.
- Make gender an enum
- Be consistent with enum capitalization
- Make middle name optional
- Add optional gender field
- Add last_updated_on field
- Add optional benefits subtype
- Add optional formulary_url field
- Make copay_opt and coinsurance_opt fields optional
- Add spoken languages
- Change facility type from string to array of string
- Change specialty type from string to array of string
